### PR TITLE
fix [options.name-format] docs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -42,7 +42,7 @@ Returns markdown documentation from jsdoc-annoted source code.
 | [options.plugin] | <code>string</code> \| <code>Array.&lt;string&gt;</code> | Use an installed package containing helper and/or partial overrides. |
 | [options.helper] | <code>string</code> \| <code>Array.&lt;string&gt;</code> | handlebars helper files to override or extend the default set. |
 | [options.partial] | <code>string</code> \| <code>Array.&lt;string&gt;</code> | handlebars partial files to override or extend the default set. |
-| [options.name-format] | <code>string</code> | Format identifier names as code (i.e. wrap function/property/class etc names in backticks). |
+| [options.name-format] | <code>boolean</code> | Format identifier names as code (i.e. wrap function/property/class etc names in backticks). |
 | [options.no-gfm] | <code>boolean</code> | By default, dmd generates github-flavoured markdown. Not all markdown parsers render gfm correctly. If your generated docs look incorrect on sites other than Github (e.g. npmjs.org) try enabling this option to disable Github-specific syntax. |
 | [options.separators] | <code>boolean</code> | Put `<hr>` breaks between identifiers. Improves readability on bulky docs. |
 | [options.module-index-format] | <code>string</code> | none, grouped, table, dl. |

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ class JsdocToMarkdown {
    * @param [options.plugin] {string|string[]} - Use an installed package containing helper and/or partial overrides.
    * @param [options.helper] {string|string[]} - handlebars helper files to override or extend the default set.
    * @param [options.partial] {string|string[]} - handlebars partial files to override or extend the default set.
-   * @param [options.name-format] {string} - Format identifier names as code (i.e. wrap function/property/class etc names in backticks).
+   * @param [options.name-format] {boolean} - Format identifier names as code (i.e. wrap function/property/class etc names in backticks).
    * @param [options.no-gfm] {boolean} - By default, dmd generates github-flavoured markdown. Not all markdown parsers render gfm correctly. If your generated docs look incorrect on sites other than Github (e.g. npmjs.org) try enabling this option to disable Github-specific syntax.
    * @param [options.separators] {boolean} - Put `<hr>` breaks between identifiers. Improves readability on bulky docs.
    * @param [options.module-index-format] {string} - none, grouped, table, dl.


### PR DESCRIPTION
The [options.name-format] parameter for jsdoc2md.render()
is show as a `string` instead of a `boolean` data type.