### PR TITLE
fix(docs): reorder installation and change synopsis to usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,15 @@ _Upgraders, please read the [release notes](https://github.com/jsdoc2md/jsdoc-to
 
 Generates markdown API documentation from [jsdoc](http://usejsdoc.org) annotated source code. Useful for injecting API docs into project README files.
 
-## Synopsis
+## Install
+
+```
+$ npm install --save-dev jsdoc-to-markdown
+```
+
+## Usage
+
+Follow the instructions below to use jsdoc2md until you get the markdown result.
 
 1\. Document your code using valid jsdoc comments.
 
@@ -46,12 +54,6 @@ A quite wonderful function.
 | cloak  | <code>object</code> | Privacy gown |
 | dagger | <code>object</code> | Security     |
 
-```
-
-## Install
-
-```
-$ npm install --save-dev jsdoc-to-markdown
 ```
 
 ## See also


### PR DESCRIPTION
## Description

Reorder installation because it will be easier if the installation is in the first step in using a library in a documentation, I don't know why the synopsis comes first (which now i change it to usage), change synopsis to usage, since the meaning is more to **usage**.

