### PR TITLE
Updated expired url

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -84,7 +84,7 @@ Returns raw data direct from the underlying [jsdoc3](https://github.com/jsdoc3/j
 | [options.no-cache] | <code>boolean</code> | By default results are cached to speed up repeat invocations. Set to true to disable this. |
 | [options.files] | <code>string</code> \| <code>Array.&lt;string&gt;</code> | One or more filenames to process. Accepts globs (e.g. `*.js`). Either `files`, `source` or `data` must be supplied. |
 | [options.source] | <code>string</code> | A string containing source code to process. Either `files`, `source` or `data` must be supplied. |
-| [options.configure] | <code>string</code> | The path to the [jsdoc configuration file](http://usejsdoc.org/about-configuring-jsdoc.html). Default: path/to/jsdoc/conf.json. |
+| [options.configure] | <code>string</code> | The path to the [jsdoc configuration file](https://jsdoc.app/about-configuring-jsdoc.html). Default: path/to/jsdoc/conf.json. |
 
 <a name="module_jsdoc-to-markdown--JsdocToMarkdown+clear"></a>
 


### PR DESCRIPTION
`http://usejsdoc.org/about-configuring-jsdoc.html` is moved so I changed it to `https://jsdoc.app/about-configuring-jsdoc.html`