### PR TITLE
Update all `http://usejsdoc.org` URLs in Repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ _Upgraders, please read the [release notes](https://github.com/jsdoc2md/jsdoc-to
 
 # jsdoc-to-markdown
 
-Generates markdown API documentation from [jsdoc](http://usejsdoc.org) annotated source code. Useful for injecting API docs into project README files.
+Generates markdown API documentation from [jsdoc](https://jsdoc.app) annotated source code. Useful for injecting API docs into project README files.
 
 ## Synopsis
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -96,7 +96,7 @@ By default, the output of each invocation of the main generation methods (`rende
 <a name="module_jsdoc-to-markdown--JsdocToMarkdown+getNamepaths"></a>
 
 ### jsdoc2md.getNamepaths(options) ⇒ <code>object</code>
-Returns all [jsdoc namepaths](http://usejsdoc.org/about-namepaths.html) found in the supplied source code.
+Returns all [jsdoc namepaths](https://jsdoc.app/about-namepaths.html) found in the supplied source code.
 
 **Kind**: instance method of [<code>JsdocToMarkdown</code>](#exp_module_jsdoc-to-markdown--JsdocToMarkdown)  
 **Category**: async  
@@ -145,4 +145,3 @@ Sync version of [getJsdocData](#module_jsdoc-to-markdown--JsdocToMarkdown+getJsd
 | Param | Type | Description |
 | --- | --- | --- |
 | [options] | <code>object</code> | Identical options to [getJsdocData](#module_jsdoc-to-markdown--JsdocToMarkdown+getJsdocData). |
-

--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ class JsdocToMarkdown {
    * @param [options.no-cache] {boolean} - By default results are cached to speed up repeat invocations. Set to true to disable this.
    * @param [options.files] {string|string[]} - One or more filenames to process. Accepts globs (e.g. `*.js`). Either `files`, `source` or `data` must be supplied.
    * @param [options.source] {string} - A string containing source code to process. Either `files`, `source` or `data` must be supplied.
-   * @param [options.configure] {string} - The path to the [jsdoc configuration file](http://usejsdoc.org/about-configuring-jsdoc.html). Default: path/to/jsdoc/conf.json.
+   * @param [options.configure] {string} - The path to the [jsdoc configuration file](https://jsdoc.app/about-configuring-jsdoc.html). Default: path/to/jsdoc/conf.json.
    * @return {Promise}
    * @fulfil {object[]}
    * @category async
@@ -141,7 +141,7 @@ class JsdocToMarkdown {
   }
 
   /**
-   * Returns all [jsdoc namepaths](http://usejsdoc.org/about-namepaths.html) found in the supplied source code.
+   * Returns all [jsdoc namepaths](https://jsdoc.app/about-namepaths.html) found in the supplied source code.
    * @param {object} - options to pass to {@link module:jsdoc-to-markdown#getTemplateData}
    * @returns {object}
    * @category async


### PR DESCRIPTION
Updated all offending URLs that no longer point to a valid location and ensured the new URLs all resolve as one would expect.

Simple PR that can hopefully improve the experience for those that are new or unfamiliar with the project wanting/needing to learn more.

---

Also sorry if this is bad form, but I've meant to submit some information regarding the Wiki's ["In the Wild"](https://github.com/jsdoc2md/jsdoc-to-markdown/wiki/Exemplary-APIs) examples.

I'm one of the core developers of Pulsar, focused on the backend, and we use this repo for generating our [Source Code Documentation](https://github.com/pulsar-edit/package-backend/blob/main/docs/reference/Source_Documentation.md).

Feel free to list it there if you'd like! Also first time contributor so feel free to let me know if there's something that can be done to improve my PR, thanks.

---

Resolves #186 