### PR TITLE
Support clever links and monospace links options

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -50,6 +50,8 @@ Returns markdown documentation from jsdoc-annoted source code.
 | [options.param-list-format] |  | Two options to render parameter lists: 'list' or 'table' (default). Table format works well in most cases but switch to list if things begin to look crowded / squashed. |
 | [options.property-list-format] |  | list, table. |
 | [options.member-index-format] |  | grouped, list |
+| [options.clever-links] | <code>boolean</code> | If true, then implements jsdoc 'cleverLinks' algorithm; `{@link}` tags captions with a URL link are rendered in plain text and captions with non-URL links are rendered in monospace. |
+| [options.monospace-links] | <code>boolean</code> | If true, then `{@link}` tags are rendered in monospace. This option is ignored if `clever-links` is true. |
 
 **Example**  
 Pass in filepaths (`**` glob matching supported) of javascript source files:
@@ -145,3 +147,4 @@ Sync version of [getJsdocData](#module_jsdoc-to-markdown--JsdocToMarkdown+getJsd
 | Param | Type | Description |
 | --- | --- | --- |
 | [options] | <code>object</code> | Identical options to [getJsdocData](#module_jsdoc-to-markdown--JsdocToMarkdown+getJsdocData). |
+

--- a/index.js
+++ b/index.js
@@ -33,6 +33,8 @@ class JsdocToMarkdown {
    * @param [options.param-list-format] {} - Two options to render parameter lists: 'list' or 'table' (default). Table format works well in most cases but switch to list if things begin to look crowded / squashed.
    * @param [options.property-list-format] {} - list, table.
    * @param [options.member-index-format] {} - grouped, list
+   * @param [options.clever-links] {boolean} - If true, then implements jsdoc 'cleverLinks' algorithm; `{@link}` tags captions with a URL link are rendered in plain text and captions with non-URL links are rendered in monospace.
+   * @param [options.monospace-links] {boolean} - If true, then `{@link}` tags are rendered in monospace. This option is ignored if `clever-links` is true.
    * @return {Promise}
    * @fulfil {string} - the rendered docs
    * @category async

--- a/lib/cli-data.js
+++ b/lib/cli-data.js
@@ -150,6 +150,16 @@ const dmdDefinitions = [
     name: 'member-index-format',
     type: String,
     description: 'Two options to render member lists: [bold]{list} or [bold]{grouped} (default). The [bold]{list} view is loosely-based on the nodejs docs.'
+  },
+  {
+    name: 'clever-links',
+    type: Boolean,
+    description: 'If true, [bold]{{@link XXX}} tags are rendered in normal text if XXX is a URL and monospace (code) format otherwise.'
+  },
+  {
+    name: 'monospace-links',
+    type: Boolean,
+    description: 'If true, all [bold]{{@link}} tags are rendered in monospace (code) format. This setting is ignored in [bold]{--clever-links} is true.'
   }
 ]
 


### PR DESCRIPTION
Adds `--clever-links` and `--monospace-links` to the CLI spec and updates the documentation.

Closes #301 